### PR TITLE
Ensure AssetHub and BridgeHub uses the same create foreign asset deposit config

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2005,6 +2005,7 @@ dependencies = [
  "scale-info",
  "sp-core 28.0.0",
  "staging-xcm",
+ "testnet-parachains-constants",
 ]
 
 [[package]]
@@ -2017,6 +2018,7 @@ dependencies = [
  "scale-info",
  "sp-core 28.0.0",
  "staging-xcm",
+ "testnet-parachains-constants",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2565,6 +2565,7 @@ name = "bridge-hub-westend-integration-tests"
 version = "1.0.0"
 dependencies = [
  "asset-hub-westend-runtime",
+ "bp-asset-hub-westend",
  "bridge-hub-westend-runtime",
  "cumulus-pallet-parachain-system",
  "cumulus-pallet-xcmp-queue",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2370,7 +2370,6 @@ version = "1.0.0"
 dependencies = [
  "asset-hub-rococo-runtime",
  "bp-asset-hub-rococo",
- "bridge-hub-rococo-runtime",
  "cumulus-pallet-xcmp-queue",
  "emulated-integration-tests-common",
  "frame-support",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2368,6 +2368,8 @@ dependencies = [
 name = "bridge-hub-rococo-integration-tests"
 version = "1.0.0"
 dependencies = [
+ "asset-hub-rococo-runtime",
+ "bridge-hub-rococo-runtime",
  "cumulus-pallet-xcmp-queue",
  "emulated-integration-tests-common",
  "frame-support",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2369,6 +2369,7 @@ name = "bridge-hub-rococo-integration-tests"
 version = "1.0.0"
 dependencies = [
  "asset-hub-rococo-runtime",
+ "bp-asset-hub-rococo",
  "bridge-hub-rococo-runtime",
  "cumulus-pallet-xcmp-queue",
  "emulated-integration-tests-common",

--- a/bridges/chains/chain-asset-hub-rococo/Cargo.toml
+++ b/bridges/chains/chain-asset-hub-rococo/Cargo.toml
@@ -23,6 +23,7 @@ sp-core = { workspace = true }
 
 # Bridge Dependencies
 bp-xcm-bridge-hub-router = { workspace = true }
+testnet-parachains-constants = { features = ["rococo"], workspace = true }
 
 # Polkadot dependencies
 xcm = { workspace = true }
@@ -35,5 +36,6 @@ std = [
 	"frame-support/std",
 	"scale-info/std",
 	"sp-core/std",
+	"testnet-parachains-constants/std",
 	"xcm/std",
 ]

--- a/bridges/chains/chain-asset-hub-rococo/src/lib.rs
+++ b/bridges/chains/chain-asset-hub-rococo/src/lib.rs
@@ -24,6 +24,7 @@ use codec::{Decode, Encode};
 use scale_info::TypeInfo;
 
 pub use bp_xcm_bridge_hub_router::XcmBridgeHubRouterCall;
+use testnet_parachains_constants::rococo::currency::UNITS;
 use xcm::latest::prelude::*;
 
 /// `AssetHubRococo` Runtime `Call` enum.
@@ -45,6 +46,8 @@ pub enum Call {
 frame_support::parameter_types! {
 	/// Some sane weight to execute `xcm::Transact(pallet-xcm-bridge-hub-router::Call::report_bridge_status)`.
 	pub const XcmBridgeHubRouterTransactCallMaxWeight: frame_support::weights::Weight = frame_support::weights::Weight::from_parts(200_000_000, 6144);
+	/// Should match the `AssetDeposit` of the `ForeignAssets` pallet on Asset Hub.
+	pub const CreateForeignAssetDeposit: u128 = UNITS / 10;
 }
 
 /// Builds an (un)congestion XCM program with the `report_bridge_status` call for

--- a/bridges/chains/chain-asset-hub-westend/Cargo.toml
+++ b/bridges/chains/chain-asset-hub-westend/Cargo.toml
@@ -23,6 +23,7 @@ sp-core = { workspace = true }
 
 # Bridge Dependencies
 bp-xcm-bridge-hub-router = { workspace = true }
+testnet-parachains-constants = { features = ["westend"], workspace = true }
 
 # Polkadot dependencies
 xcm = { workspace = true }
@@ -35,5 +36,6 @@ std = [
 	"frame-support/std",
 	"scale-info/std",
 	"sp-core/std",
+	"testnet-parachains-constants/std",
 	"xcm/std",
 ]

--- a/bridges/chains/chain-asset-hub-westend/src/lib.rs
+++ b/bridges/chains/chain-asset-hub-westend/src/lib.rs
@@ -24,6 +24,7 @@ use codec::{Decode, Encode};
 use scale_info::TypeInfo;
 
 pub use bp_xcm_bridge_hub_router::XcmBridgeHubRouterCall;
+use testnet_parachains_constants::westend::currency::UNITS;
 use xcm::latest::prelude::*;
 
 /// `AssetHubWestend` Runtime `Call` enum.
@@ -45,6 +46,9 @@ pub enum Call {
 frame_support::parameter_types! {
 	/// Some sane weight to execute `xcm::Transact(pallet-xcm-bridge-hub-router::Call::report_bridge_status)`.
 	pub const XcmBridgeHubRouterTransactCallMaxWeight: frame_support::weights::Weight = frame_support::weights::Weight::from_parts(200_000_000, 6144);
+
+	/// Should match the `AssetDeposit` of the `ForeignAssets` pallet on Asset Hub.
+	pub const CreateForeignAssetDeposit: u128 = UNITS / 10;
 }
 
 /// Builds an (un)congestion XCM program with the `report_bridge_status` call for

--- a/cumulus/parachains/integration-tests/emulated/tests/bridges/bridge-hub-rococo/Cargo.toml
+++ b/cumulus/parachains/integration-tests/emulated/tests/bridges/bridge-hub-rococo/Cargo.toml
@@ -32,6 +32,7 @@ xcm-executor = { workspace = true }
 xcm-runtime-apis = { workspace = true }
 
 # Bridges
+bp-asset-hub-rococo = { workspace = true }
 pallet-bridge-messages = { workspace = true }
 
 # Cumulus

--- a/cumulus/parachains/integration-tests/emulated/tests/bridges/bridge-hub-rococo/Cargo.toml
+++ b/cumulus/parachains/integration-tests/emulated/tests/bridges/bridge-hub-rococo/Cargo.toml
@@ -37,7 +37,6 @@ pallet-bridge-messages = { workspace = true }
 
 # Cumulus
 asset-hub-rococo-runtime = { workspace = true }
-bridge-hub-rococo-runtime = { workspace = true }
 cumulus-pallet-xcmp-queue = { workspace = true }
 emulated-integration-tests-common = { workspace = true }
 parachains-common = { workspace = true, default-features = true }

--- a/cumulus/parachains/integration-tests/emulated/tests/bridges/bridge-hub-rococo/Cargo.toml
+++ b/cumulus/parachains/integration-tests/emulated/tests/bridges/bridge-hub-rococo/Cargo.toml
@@ -35,6 +35,8 @@ xcm-runtime-apis = { workspace = true }
 pallet-bridge-messages = { workspace = true }
 
 # Cumulus
+asset-hub-rococo-runtime = { workspace = true }
+bridge-hub-rococo-runtime = { workspace = true }
 cumulus-pallet-xcmp-queue = { workspace = true }
 emulated-integration-tests-common = { workspace = true }
 parachains-common = { workspace = true, default-features = true }

--- a/cumulus/parachains/integration-tests/emulated/tests/bridges/bridge-hub-rococo/src/tests/snowbridge.rs
+++ b/cumulus/parachains/integration-tests/emulated/tests/bridges/bridge-hub-rococo/src/tests/snowbridge.rs
@@ -874,3 +874,14 @@ fn send_weth_from_ethereum_to_non_existent_account_on_asset_hub_with_sufficient_
 		);
 	});
 }
+
+#[test]
+fn create_foreign_asset_deposit_is_equal_to_asset_hub_foreign_asset_pallet_deposit() {
+	let asset_hub_deposit = asset_hub_rococo_runtime::ForeignAssetsAssetDeposit::get();
+	let bridge_hub_deposit = bridge_hub_rococo_runtime::bridge_to_ethereum_config::CreateAssetDeposit::get();
+	assert!(
+		bridge_hub_deposit <=
+			asset_hub_deposit,
+		"The BridgeHub asset creation deposit must be equal to or larger than the asset creation deposit configured on BridgeHub"
+	);
+}

--- a/cumulus/parachains/integration-tests/emulated/tests/bridges/bridge-hub-rococo/src/tests/snowbridge.rs
+++ b/cumulus/parachains/integration-tests/emulated/tests/bridges/bridge-hub-rococo/src/tests/snowbridge.rs
@@ -209,6 +209,8 @@ fn create_channel() {
 fn register_weth_token_from_ethereum_to_asset_hub() {
 	// Fund AssetHub sovereign account so that it can pay execution fees.
 	BridgeHubRococo::fund_para_sovereign(AssetHubRococo::para_id().into(), INITIAL_FUND);
+	// Fund ethereum sovereign on AssetHub to satisfy ED
+	AssetHubRococo::fund_accounts(vec![(snowbridge_sovereign(), INITIAL_FUND)]);
 
 	BridgeHubRococo::execute_with(|| {
 		type RuntimeEvent = <BridgeHubRococo as Chain>::RuntimeEvent;
@@ -242,9 +244,11 @@ fn register_weth_token_from_ethereum_to_asset_hub() {
 #[test]
 fn send_weth_token_from_ethereum_to_asset_hub() {
 	BridgeHubRococo::fund_para_sovereign(AssetHubRococo::para_id().into(), INITIAL_FUND);
-
-	// Fund ethereum sovereign on AssetHub
-	AssetHubRococo::fund_accounts(vec![(AssetHubRococoReceiver::get(), INITIAL_FUND)]);
+	// Fund ethereum sovereign and receiver on AssetHub to satisfy ED
+	AssetHubRococo::fund_accounts(vec![
+		(snowbridge_sovereign(), INITIAL_FUND),
+		(AssetHubRococoReceiver::get(), INITIAL_FUND),
+	]);
 
 	BridgeHubRococo::execute_with(|| {
 		type RuntimeEvent = <BridgeHubRococo as Chain>::RuntimeEvent;
@@ -406,7 +410,10 @@ fn send_weth_asset_from_asset_hub_to_ethereum() {
 	);
 
 	BridgeHubRococo::fund_accounts(vec![(assethub_sovereign.clone(), INITIAL_FUND)]);
-	AssetHubRococo::fund_accounts(vec![(AssetHubRococoReceiver::get(), INITIAL_FUND)]);
+	AssetHubRococo::fund_accounts(vec![
+		(AssetHubRococoReceiver::get(), INITIAL_FUND),
+		(snowbridge_sovereign(), INITIAL_FUND),
+	]);
 
 	const WETH_AMOUNT: u128 = 1_000_000_000;
 
@@ -878,10 +885,27 @@ fn send_weth_from_ethereum_to_non_existent_account_on_asset_hub_with_sufficient_
 #[test]
 fn create_foreign_asset_deposit_is_equal_to_asset_hub_foreign_asset_pallet_deposit() {
 	let asset_hub_deposit = asset_hub_rococo_runtime::ForeignAssetsAssetDeposit::get();
-	let bridge_hub_deposit = bridge_hub_rococo_runtime::bridge_to_ethereum_config::CreateAssetDeposit::get();
+	let bridge_hub_deposit = bp_asset_hub_rococo::CreateForeignAssetDeposit::get();
 	assert!(
-		bridge_hub_deposit <=
+		bridge_hub_deposit >=
 			asset_hub_deposit,
 		"The BridgeHub asset creation deposit must be equal to or larger than the asset creation deposit configured on BridgeHub"
 	);
+}
+
+pub fn snowbridge_sovereign() -> sp_runtime::AccountId32 {
+	use asset_hub_rococo_runtime::xcm_config::UniversalLocation as AssetHubWestendUniversalLocation;
+	let ethereum_sovereign: AccountId = AssetHubRococo::execute_with(|| {
+		ExternalConsensusLocationsConverterFor::<
+			AssetHubWestendUniversalLocation,
+			[u8; 32],
+		>::convert_location(&Location::new(
+			2,
+			[xcm::v5::Junction::GlobalConsensus(EthereumNetwork::get())],
+		))
+			.unwrap()
+			.into()
+	});
+
+	ethereum_sovereign
 }

--- a/cumulus/parachains/integration-tests/emulated/tests/bridges/bridge-hub-westend/Cargo.toml
+++ b/cumulus/parachains/integration-tests/emulated/tests/bridges/bridge-hub-westend/Cargo.toml
@@ -39,6 +39,7 @@ pallet-bridge-messages = { workspace = true }
 pallet-bridge-relayers = { workspace = true }
 
 # Cumulus
+bp-asset-hub-westend = { workspace = true }
 asset-hub-westend-runtime = { workspace = true }
 bridge-hub-westend-runtime = { workspace = true }
 cumulus-pallet-parachain-system = { workspace = true }

--- a/cumulus/parachains/integration-tests/emulated/tests/bridges/bridge-hub-westend/src/tests/snowbridge.rs
+++ b/cumulus/parachains/integration-tests/emulated/tests/bridges/bridge-hub-westend/src/tests/snowbridge.rs
@@ -78,6 +78,10 @@ pub fn send_inbound_message(fixture: InboundQueueFixture) -> DispatchResult {
 fn register_weth_token_from_ethereum_to_asset_hub() {
 	// Fund AssetHub sovereign account so that it can pay execution fees.
 	BridgeHubWestend::fund_para_sovereign(AssetHubWestend::para_id().into(), INITIAL_FUND);
+	// Fund Snowbridge Sovereign to satisfy ED.
+	AssetHubWestend::fund_accounts(vec![
+		(snowbridge_sovereign(), INITIAL_FUND),
+	]);
 
 	BridgeHubWestend::execute_with(|| {
 		type RuntimeEvent = <BridgeHubWestend as Chain>::RuntimeEvent;

--- a/cumulus/parachains/integration-tests/emulated/tests/bridges/bridge-hub-westend/src/tests/snowbridge_v2_inbound.rs
+++ b/cumulus/parachains/integration-tests/emulated/tests/bridges/bridge-hub-westend/src/tests/snowbridge_v2_inbound.rs
@@ -22,7 +22,7 @@ use crate::{
 use asset_hub_westend_runtime::ForeignAssets;
 use bridge_hub_westend_runtime::{
 	bridge_common_config::BridgeReward,
-	bridge_to_ethereum_config::{CreateAssetCall, CreateAssetDeposit, EthereumGatewayAddress},
+	bridge_to_ethereum_config::{CreateAssetCall, EthereumGatewayAddress},
 	EthereumInboundQueueV2,
 };
 use codec::Encode;
@@ -391,7 +391,7 @@ fn register_and_send_multiple_tokens_v2() {
 	let weth_transfer_value = 2_500_000_000_000u128;
 
 	let dot_asset = Location::new(1, Here);
-	let dot_fee: xcm::prelude::Asset = (dot_asset, CreateAssetDeposit::get()).into();
+	let dot_fee: xcm::prelude::Asset = (dot_asset, bp_asset_hub_westend::CreateForeignAssetDeposit::get()).into();
 
 	// Used to pay the asset creation deposit.
 	let eth_asset_value = 9_000_000_000_000u128;
@@ -1022,4 +1022,15 @@ fn invalid_claimer_does_not_fail_the_message() {
 			"Assets were trapped, should not happen."
 		);
 	});
+}
+
+#[test]
+fn create_foreign_asset_deposit_is_equal_to_asset_hub_foreign_asset_pallet_deposit() {
+	let asset_hub_deposit = asset_hub_westend_runtime::ForeignAssetsAssetDeposit::get();
+	let bridge_hub_deposit = bp_asset_hub_westend::CreateForeignAssetDeposit::get();
+	assert_eq!(
+		asset_hub_deposit,
+		bridge_hub_deposit,
+		"The deposit values must match between AssetHub and BridgeHub"
+	);
 }

--- a/cumulus/parachains/integration-tests/emulated/tests/bridges/bridge-hub-westend/src/tests/snowbridge_v2_inbound.rs
+++ b/cumulus/parachains/integration-tests/emulated/tests/bridges/bridge-hub-westend/src/tests/snowbridge_v2_inbound.rs
@@ -391,7 +391,8 @@ fn register_and_send_multiple_tokens_v2() {
 	let weth_transfer_value = 2_500_000_000_000u128;
 
 	let dot_asset = Location::new(1, Here);
-	let dot_fee: xcm::prelude::Asset = (dot_asset, bp_asset_hub_westend::CreateForeignAssetDeposit::get()).into();
+	let dot_fee: xcm::prelude::Asset =
+		(dot_asset, bp_asset_hub_westend::CreateForeignAssetDeposit::get()).into();
 
 	// Used to pay the asset creation deposit.
 	let eth_asset_value = 9_000_000_000_000u128;
@@ -1028,9 +1029,9 @@ fn invalid_claimer_does_not_fail_the_message() {
 fn create_foreign_asset_deposit_is_equal_to_asset_hub_foreign_asset_pallet_deposit() {
 	let asset_hub_deposit = asset_hub_westend_runtime::ForeignAssetsAssetDeposit::get();
 	let bridge_hub_deposit = bp_asset_hub_westend::CreateForeignAssetDeposit::get();
-	assert_eq!(
+	assert!(
+		bridge_hub_deposit <=
 		asset_hub_deposit,
-		bridge_hub_deposit,
-		"The deposit values must match between AssetHub and BridgeHub"
+		"The BridgeHub asset creation deposit must be equal to or larger than the asset creation deposit configured on BridgeHub"
 	);
 }

--- a/cumulus/parachains/integration-tests/emulated/tests/bridges/bridge-hub-westend/src/tests/snowbridge_v2_inbound.rs
+++ b/cumulus/parachains/integration-tests/emulated/tests/bridges/bridge-hub-westend/src/tests/snowbridge_v2_inbound.rs
@@ -1030,7 +1030,7 @@ fn create_foreign_asset_deposit_is_equal_to_asset_hub_foreign_asset_pallet_depos
 	let asset_hub_deposit = asset_hub_westend_runtime::ForeignAssetsAssetDeposit::get();
 	let bridge_hub_deposit = bp_asset_hub_westend::CreateForeignAssetDeposit::get();
 	assert!(
-		bridge_hub_deposit <=
+		bridge_hub_deposit >=
 		asset_hub_deposit,
 		"The BridgeHub asset creation deposit must be equal to or larger than the asset creation deposit configured on BridgeHub"
 	);

--- a/cumulus/parachains/runtimes/assets/asset-hub-rococo/src/lib.rs
+++ b/cumulus/parachains/runtimes/assets/asset-hub-rococo/src/lib.rs
@@ -461,8 +461,7 @@ impl pallet_asset_conversion_ops::Config for Runtime {
 }
 
 parameter_types! {
-	// we just reuse the same deposits
-	pub const ForeignAssetsAssetDeposit: Balance = AssetDeposit::get();
+	pub const ForeignAssetsAssetDeposit: Balance = CreateForeignAssetDeposit::get();
 	pub const ForeignAssetsAssetAccountDeposit: Balance = AssetAccountDeposit::get();
 	pub const ForeignAssetsApprovalDeposit: Balance = ApprovalDeposit::get();
 	pub const ForeignAssetsAssetsStringLimit: u32 = AssetsStringLimit::get();

--- a/cumulus/parachains/runtimes/assets/asset-hub-rococo/src/lib.rs
+++ b/cumulus/parachains/runtimes/assets/asset-hub-rococo/src/lib.rs
@@ -48,6 +48,7 @@ use sp_runtime::{
 	ApplyExtrinsicResult, Permill,
 };
 use testnet_parachains_constants::rococo::snowbridge::EthereumNetwork;
+use bp_asset_hub_rococo::CreateForeignAssetDeposit;
 
 #[cfg(feature = "std")]
 use sp_version::NativeVersion;

--- a/cumulus/parachains/runtimes/assets/asset-hub-westend/src/lib.rs
+++ b/cumulus/parachains/runtimes/assets/asset-hub-westend/src/lib.rs
@@ -36,6 +36,7 @@ use assets_common::{
 	local_and_foreign_assets::{LocalFromLeft, TargetFromLeft},
 	AssetIdForPoolAssets, AssetIdForPoolAssetsConvert, AssetIdForTrustBackedAssetsConvert,
 };
+use bp_asset_hub_westend::CreateForeignAssetDeposit;
 use codec::{Decode, DecodeWithMemTracking, Encode, MaxEncodedLen};
 use cumulus_pallet_parachain_system::RelayNumberMonotonicallyIncreases;
 use cumulus_primitives_core::{AggregateMessageOrigin, ClaimQueueOffset, CoreSelector, ParaId};
@@ -514,8 +515,7 @@ impl pallet_asset_conversion_ops::Config for Runtime {
 }
 
 parameter_types! {
-	// we just reuse the same deposits
-	pub const ForeignAssetsAssetDeposit: Balance = AssetDeposit::get();
+	pub const ForeignAssetsAssetDeposit: Balance = CreateForeignAssetDeposit::get();
 	pub const ForeignAssetsAssetAccountDeposit: Balance = AssetAccountDeposit::get();
 	pub const ForeignAssetsApprovalDeposit: Balance = ApprovalDeposit::get();
 	pub const ForeignAssetsAssetsStringLimit: u32 = AssetsStringLimit::get();

--- a/cumulus/parachains/runtimes/bridge-hubs/bridge-hub-rococo/src/bridge_to_ethereum_config.rs
+++ b/cumulus/parachains/runtimes/bridge-hubs/bridge-hub-rococo/src/bridge_to_ethereum_config.rs
@@ -62,7 +62,6 @@ parameter_types! {
 }
 
 parameter_types! {
-	pub const CreateAssetDeposit: u128 = CreateForeignAssetDeposit::get() + EXISTENTIAL_DEPOSIT;
 	pub const CreateAssetCall: [u8;2] = [53, 0];
 	pub Parameters: PricingParameters<u128> = PricingParameters {
 		exchange_rate: FixedU128::from_rational(1, 400),

--- a/cumulus/parachains/runtimes/bridge-hubs/bridge-hub-rococo/src/bridge_to_ethereum_config.rs
+++ b/cumulus/parachains/runtimes/bridge-hubs/bridge-hub-rococo/src/bridge_to_ethereum_config.rs
@@ -62,6 +62,7 @@ parameter_types! {
 }
 
 parameter_types! {
+	pub const CreateAssetDeposit: u128 = CreateForeignAssetDeposit::get() + EXISTENTIAL_DEPOSIT;
 	pub const CreateAssetCall: [u8;2] = [53, 0];
 	pub Parameters: PricingParameters<u128> = PricingParameters {
 		exchange_rate: FixedU128::from_rational(1, 400),

--- a/cumulus/parachains/runtimes/bridge-hubs/bridge-hub-rococo/src/bridge_to_ethereum_config.rs
+++ b/cumulus/parachains/runtimes/bridge-hubs/bridge-hub-rococo/src/bridge_to_ethereum_config.rs
@@ -37,6 +37,7 @@ use testnet_parachains_constants::rococo::{
 use crate::xcm_config::RelayNetwork;
 #[cfg(feature = "runtime-benchmarks")]
 use benchmark_helpers::DoNothingRouter;
+use bp_asset_hub_rococo::CreateForeignAssetDeposit;
 use frame_support::{parameter_types, weights::ConstantMultiplier};
 use hex_literal::hex;
 use pallet_xcm::EnsureXcm;
@@ -62,7 +63,6 @@ parameter_types! {
 
 parameter_types! {
 	pub const CreateAssetCall: [u8;2] = [53, 0];
-	pub const CreateAssetDeposit: u128 = (UNITS / 10) + EXISTENTIAL_DEPOSIT;
 	pub Parameters: PricingParameters<u128> = PricingParameters {
 		exchange_rate: FixedU128::from_rational(1, 400),
 		fee_per_gas: gwei(20),
@@ -87,7 +87,7 @@ impl snowbridge_pallet_inbound_queue::Config for Runtime {
 	type Helper = Runtime;
 	type MessageConverter = MessageToXcm<
 		CreateAssetCall,
-		CreateAssetDeposit,
+		CreateForeignAssetDeposit,
 		ConstU8<INBOUND_QUEUE_PALLET_INDEX>,
 		AccountId,
 		Balance,

--- a/cumulus/parachains/runtimes/bridge-hubs/bridge-hub-westend/src/bridge_to_ethereum_config.rs
+++ b/cumulus/parachains/runtimes/bridge-hubs/bridge-hub-westend/src/bridge_to_ethereum_config.rs
@@ -76,6 +76,7 @@ parameter_types! {
 }
 
 parameter_types! {
+	pub const CreateAssetDeposit: u128 = CreateForeignAssetDeposit::get() + EXISTENTIAL_DEPOSIT;
 	pub const CreateAssetCall: [u8;2] = [53, 0];
 	pub Parameters: PricingParameters<u128> = PricingParameters {
 		exchange_rate: FixedU128::from_rational(1, 400),
@@ -106,7 +107,7 @@ impl snowbridge_pallet_inbound_queue::Config for Runtime {
 	type Helper = Runtime;
 	type MessageConverter = snowbridge_inbound_queue_primitives::v1::MessageToXcm<
 		CreateAssetCall,
-		CreateForeignAssetDeposit,
+		CreateAssetDeposit,
 		ConstU8<INBOUND_QUEUE_PALLET_INDEX_V1>,
 		AccountId,
 		Balance,
@@ -141,7 +142,7 @@ impl snowbridge_pallet_inbound_queue_v2::Config for Runtime {
 	type WeightToFee = WeightToFee;
 	type MessageConverter = snowbridge_inbound_queue_primitives::v2::MessageToXcm<
 		CreateAssetCall,
-		CreateForeignAssetDeposit,
+		CreateAssetDeposit,
 		EthereumNetwork,
 		InboundQueueLocation,
 		EthereumSystem,

--- a/cumulus/parachains/runtimes/bridge-hubs/bridge-hub-westend/src/bridge_to_ethereum_config.rs
+++ b/cumulus/parachains/runtimes/bridge-hubs/bridge-hub-westend/src/bridge_to_ethereum_config.rs
@@ -76,7 +76,6 @@ parameter_types! {
 }
 
 parameter_types! {
-	pub const CreateAssetDeposit: u128 = CreateForeignAssetDeposit::get() + EXISTENTIAL_DEPOSIT;
 	pub const CreateAssetCall: [u8;2] = [53, 0];
 	pub Parameters: PricingParameters<u128> = PricingParameters {
 		exchange_rate: FixedU128::from_rational(1, 400),
@@ -107,7 +106,7 @@ impl snowbridge_pallet_inbound_queue::Config for Runtime {
 	type Helper = Runtime;
 	type MessageConverter = snowbridge_inbound_queue_primitives::v1::MessageToXcm<
 		CreateAssetCall,
-		CreateAssetDeposit,
+		CreateForeignAssetDeposit,
 		ConstU8<INBOUND_QUEUE_PALLET_INDEX_V1>,
 		AccountId,
 		Balance,
@@ -142,7 +141,7 @@ impl snowbridge_pallet_inbound_queue_v2::Config for Runtime {
 	type WeightToFee = WeightToFee;
 	type MessageConverter = snowbridge_inbound_queue_primitives::v2::MessageToXcm<
 		CreateAssetCall,
-		CreateAssetDeposit,
+		CreateForeignAssetDeposit,
 		EthereumNetwork,
 		InboundQueueLocation,
 		EthereumSystem,

--- a/cumulus/parachains/runtimes/bridge-hubs/bridge-hub-westend/src/bridge_to_ethereum_config.rs
+++ b/cumulus/parachains/runtimes/bridge-hubs/bridge-hub-westend/src/bridge_to_ethereum_config.rs
@@ -21,6 +21,7 @@ use crate::{
 	Balances, BridgeRelayers, EthereumInboundQueue, EthereumOutboundQueue, EthereumOutboundQueueV2,
 	EthereumSystem, EthereumSystemV2, MessageQueue, Runtime, RuntimeEvent, TransactionByteFee,
 };
+use bp_asset_hub_westend::CreateForeignAssetDeposit;
 use frame_support::{parameter_types, traits::Contains, weights::ConstantMultiplier};
 use frame_system::EnsureRootWithSuccess;
 use pallet_xcm::EnsureXcm;
@@ -76,7 +77,6 @@ parameter_types! {
 
 parameter_types! {
 	pub const CreateAssetCall: [u8;2] = [53, 0];
-	pub const CreateAssetDeposit: u128 = (UNITS / 10) + EXISTENTIAL_DEPOSIT;
 	pub Parameters: PricingParameters<u128> = PricingParameters {
 		exchange_rate: FixedU128::from_rational(1, 400),
 		fee_per_gas: gwei(20),
@@ -106,7 +106,7 @@ impl snowbridge_pallet_inbound_queue::Config for Runtime {
 	type Helper = Runtime;
 	type MessageConverter = snowbridge_inbound_queue_primitives::v1::MessageToXcm<
 		CreateAssetCall,
-		CreateAssetDeposit,
+		CreateForeignAssetDeposit,
 		ConstU8<INBOUND_QUEUE_PALLET_INDEX_V1>,
 		AccountId,
 		Balance,
@@ -141,7 +141,7 @@ impl snowbridge_pallet_inbound_queue_v2::Config for Runtime {
 	type WeightToFee = WeightToFee;
 	type MessageConverter = snowbridge_inbound_queue_primitives::v2::MessageToXcm<
 		CreateAssetCall,
-		CreateAssetDeposit,
+		CreateForeignAssetDeposit,
 		EthereumNetwork,
 		InboundQueueLocation,
 		EthereumSystem,


### PR DESCRIPTION
To improve on: https://github.com/paritytech/polkadot-sdk/pull/7402#discussion_r1987592845

Follows the same pattern as the [Polkadot runtimes](https://github.com/search?q=repo%3Apolkadot-fellows%2Fruntimes%20CreateForeignAssetDeposit&type=code), by adding the create foreign asset deposit value to the bridge chain primitives.